### PR TITLE
[feature] demo of a smart search

### DIFF
--- a/src/public/js/search.js
+++ b/src/public/js/search.js
@@ -1,107 +1,104 @@
-const setSearchOn = (search_engine, keep_value='') => {
-  //console.debug('Setting search engine to', search_engine);
-  $('#search_on').html(search_engine);
-  $('#dynamic_search').val(keep_value);
-}
+const setSearchOn = (searchEngine, keepValue = '') => {
+  $('#search_on').text(searchEngine);
+  $('#dynamic_search').val(keepValue);
+};
 const doSearchAction = (terms) => {
-  //console.debug('Launching a search to', $('#search_on').text());
-  let search_engine = $('#search_on').text();
-  if (search_engine == 'DuckDuckGo') {
+  const searchEngine = $('#search_on').text();
+  if (searchEngine === 'DuckDuckGo') {
     window.open('https://duckduckgo.com/?q=' + terms);
   }
-  if (search_engine == 'EPFL Go') {
+  if (searchEngine === 'EPFL Go') {
     window.open('https://go.epfl.ch/' + terms);
   }
-  if (search_engine == 'Google') {
+  if (searchEngine === 'Google') {
     window.open('https://www.google.com/search?hl=en&q=' + terms);
   }
-  if (search_engine == 'EPFL') {
+  if (searchEngine === 'EPFL') {
     window.open('https://search.epfl.ch/?q=' + terms);
   }
-  if (search_engine == 'EPFL Map') {
+  if (searchEngine === 'EPFL Map') {
     window.open('https://plan.epfl.ch/?room=' + terms);
   }
-  if (search_engine == 'EPFL People') {
+  if (searchEngine === 'EPFL People') {
     window.open('https://search.epfl.ch/?filter=people&q=' + terms);
   }
-  if (search_engine == 'EPFL Units') {
-    window.open('https://search.epfl.ch/?filter=units&q=' + terms);
+  if (searchEngine === 'EPFL Units') {
+    window.open('https://search.epfl.ch/?filter=unit&q=' + terms);
   }
-  if (search_engine == 'ServiceNow') {
-    window.open('https://support.epfl.ch/backoffice/$sn_global_search_results.do?sysparm_view=text_search&sysparm_search=' + terms);
+  if (searchEngine === 'ServiceNow') {
+    window.open(
+      // eslint-disable-next-line
+      'https://support.epfl.ch/backoffice/$sn_global_search_results.do?sysparm_view=text_search&sysparm_search=' +
+        terms
+    );
   }
-  if (search_engine == 'Wikipedia') {
+  if (searchEngine === 'Wikipedia') {
     window.open('https://en.wikipedia.org/w/index.php?search=' + terms);
   }
-}
+};
 
-$('.dropdown-item').click(function() {
-  let searchOn = $(this).text();
-  //console.debug(searchOn);
-  setSearchOn(searchOn);
-})
+$(function () {
+  $('.dropdown-item').click(function () {
+    const searchOn = $(this).text();
+    setSearchOn(searchOn);
+  });
 
-$('#dynamic_search').bind('keyup', function(e) {
-  let terms = $(this).val();
-  //console.debug(e.keyCode, terms);
-  // backspace is pressed and input is empty
-  if (e.keyCode == 8 && !terms) {
-    //console.debug('RESET');
-    setSearchOn('EPFL');
-  }
-  // space bar is pressed
-  if (e.keyCode == 32 && terms.length > 1) {
-    let terms_array = terms.trim().split(' ');
-    //console.debug(terms_array);
-    switch (terms_array[0]) {
-      case '?':
-        setSearchOn('Google');
-        break;
-      case 'd':
-        setSearchOn('DuckDuckGo');
-        break;
-      case 'g':
-      case 'go':
-        //console.debug('terms_Array', terms_array)
-        setSearchOn('EPFL Go', terms_array[1]);
-        break;
-      case 'm':
-        setSearchOn('EPFL Map');
-        break;
-      case 'p':
-        setSearchOn('EPFL People');
-        break;
-      case 'sn':
-        setSearchOn('ServiceNow');
-        break;
-      case 'u':
-        setSearchOn('EPFL Units');
-        break;
-      case 'w':
-        setSearchOn('Wikipedia');
-        break;
-      default:
-        // do nothing
+  $('#dynamic_search').bind('keyup', function (e) {
+    const terms = $(this).val();
+    // backspace is pressed and input is empty
+    if (e.keyCode === 8 && !terms) {
+      setSearchOn('EPFL');
     }
-  }
-  // enter is pressed
-  if (e.keyCode == 13 && terms) {
-    //console.debug('GO!');
-    doSearchAction(terms);
-  }
-  // escape is pressed
-  if (e.keyCode == 27 && terms) {
-    //console.debug('clear');
-    $('#dynamic_search').val('');
-    $('#dynamic_search').focus();
-  }
-});
+    // space bar is pressed
+    if (e.keyCode === 32 && terms.length > 1) {
+      const arrayOfTerms = terms.trim().split(' ');
+      switch (arrayOfTerms[0]) {
+        case '?':
+          setSearchOn('Google');
+          break;
+        case 'd':
+          setSearchOn('DuckDuckGo');
+          break;
+        case 'g':
+        case 'go':
+          setSearchOn('EPFL Go', arrayOfTerms[1]);
+          break;
+        case 'm':
+          setSearchOn('EPFL Map');
+          break;
+        case 'p':
+          setSearchOn('EPFL People');
+          break;
+        case 'sn':
+          setSearchOn('ServiceNow');
+          break;
+        case 'u':
+          setSearchOn('EPFL Units');
+          break;
+        case 'w':
+          setSearchOn('Wikipedia');
+          break;
+        default:
+        // do nothing
+      }
+    }
+    // enter is pressed
+    if (e.keyCode === 13 && terms) {
+      doSearchAction(terms);
+    }
+    // escape is pressed
+    if (e.keyCode === 27 && terms) {
+      $('#dynamic_search').val('');
+      $('#dynamic_search').focus();
+    }
+  });
 
-// Global escape key
-$(document).keyup(function(e) {
-  if(e.keyCode == 27) {
-    $('#dynamic_search').val('');
-    $('#dynamic_search').focus();
-    // @TODO: open help or something
-  }
+  // Global escape key
+  $(document).keyup(function (e) {
+    if (e.keyCode === 27) {
+      $('#dynamic_search').val('');
+      $('#dynamic_search').focus();
+      // @TODO: open help or something
+    }
+  });
 });

--- a/src/public/js/search.js
+++ b/src/public/js/search.js
@@ -93,6 +93,15 @@ $('#dynamic_search').bind('keyup', function(e) {
   if (e.keyCode == 27 && terms) {
     //console.debug('clear');
     $('#dynamic_search').val('');
+    $('#dynamic_search').focus();
+  }
+});
+
+// Global escape key
+$(document).keyup(function(e) {
+  if(e.keyCode == 27) {
+    $('#dynamic_search').val('');
+    $('#dynamic_search').focus();
     // @TODO: open help or something
   }
 });

--- a/src/public/js/search.js
+++ b/src/public/js/search.js
@@ -1,3 +1,79 @@
-$('#search-input').on('input', function () {
-  console.log($(this).val());
+const setSearchOn = (search_engine, keep_value='') => {
+  //console.debug('Setting search engine to', search_engine);
+  $('#search_on').html(search_engine);
+  $('#dynamic_search').val(keep_value);
+}
+const doSearchAction = (terms) => {
+  //console.debug('Launching a search to', $('#search_on').text());
+  let search_engine = $('#search_on').text();
+  if (search_engine == 'Go to') {
+    window.open('https://go.epfl.ch/' + terms);
+  }
+  if (search_engine == 'Google') {
+    window.open('https://www.google.com/search?hl=en&q=' + terms);
+  }
+  if (search_engine == 'EPFL') {
+    window.open('https://search.epfl.ch/?q=' + terms);
+  }
+  if (search_engine == 'EPFL Map') {
+    window.open('https://plan.epfl.ch/?room=' + terms);
+  }
+  if (search_engine == 'EPFL People') {
+    window.open('https://search.epfl.ch/?filter=people&q=' + terms);
+  }
+  if (search_engine == 'EPFL Units') {
+    window.open('https://search.epfl.ch/?filter=units&q=' + terms);
+  }
+  if (search_engine == 'ServiceNow') {
+    window.open('https://support.epfl.ch/backoffice/$sn_global_search_results.do?sysparm_view=text_search&sysparm_search=' + terms);
+  }
+}
+
+$('#dynamic_search').bind('keyup', function(e) {
+  let terms = $(this).val();
+  //console.debug(e.keyCode, terms);
+  // backspace is pressed and input is empty
+  if (e.keyCode == 8 && !terms) {
+    //console.debug('RESET');
+    setSearchOn('EPFL');
+  }
+  // space bar is pressed
+  if (e.keyCode == 32 && terms.length > 1) {
+    let terms_array = terms.trim().split(' ');
+    //console.debug(terms_array);
+    switch (terms_array[0]) {
+      case '?':
+        setSearchOn('Google');
+        break;
+      case 'g':
+        //console.debug('terms_Array', terms_array)
+        setSearchOn('Go to', terms_array[1]);
+        break;
+      case 'm':
+        setSearchOn('EPFL Map');
+        break;
+      case 'p':
+        setSearchOn('EPFL People');
+        break;
+      case 'sn':
+        setSearchOn('ServiceNow');
+        break;
+      case 'u':
+        setSearchOn('EPFL Units');
+        break;
+      default:
+        // do nothing
+    }
+  }
+  // enter is pressed
+  if (e.keyCode == 13 && terms) {
+    //console.debug('GO!');
+    doSearchAction(terms);
+  }
+  // escape is pressed
+  if (e.keyCode == 27 && terms) {
+    //console.debug('clear');
+    $('#dynamic_search').val('');
+    // @TODO: open help or something
+  }
 });

--- a/src/public/js/search.js
+++ b/src/public/js/search.js
@@ -6,7 +6,10 @@ const setSearchOn = (search_engine, keep_value='') => {
 const doSearchAction = (terms) => {
   //console.debug('Launching a search to', $('#search_on').text());
   let search_engine = $('#search_on').text();
-  if (search_engine == 'Go to') {
+  if (search_engine == 'DuckDuckGo') {
+    window.open('https://duckduckgo.com/?q=' + terms);
+  }
+  if (search_engine == 'EPFL Go') {
     window.open('https://go.epfl.ch/' + terms);
   }
   if (search_engine == 'Google') {
@@ -27,7 +30,16 @@ const doSearchAction = (terms) => {
   if (search_engine == 'ServiceNow') {
     window.open('https://support.epfl.ch/backoffice/$sn_global_search_results.do?sysparm_view=text_search&sysparm_search=' + terms);
   }
+  if (search_engine == 'Wikipedia') {
+    window.open('https://en.wikipedia.org/w/index.php?search=' + terms);
+  }
 }
+
+$('.dropdown-item').click(function() {
+  let searchOn = $(this).text();
+  //console.debug(searchOn);
+  setSearchOn(searchOn);
+})
 
 $('#dynamic_search').bind('keyup', function(e) {
   let terms = $(this).val();
@@ -45,9 +57,13 @@ $('#dynamic_search').bind('keyup', function(e) {
       case '?':
         setSearchOn('Google');
         break;
+      case 'd':
+        setSearchOn('DuckDuckGo');
+        break;
       case 'g':
+      case 'go':
         //console.debug('terms_Array', terms_array)
-        setSearchOn('Go to', terms_array[1]);
+        setSearchOn('EPFL Go', terms_array[1]);
         break;
       case 'm':
         setSearchOn('EPFL Map');
@@ -60,6 +76,9 @@ $('#dynamic_search').bind('keyup', function(e) {
         break;
       case 'u':
         setSearchOn('EPFL Units');
+        break;
+      case 'w':
+        setSearchOn('Wikipedia');
         break;
       default:
         // do nothing

--- a/src/views/pages/home.ejs
+++ b/src/views/pages/home.ejs
@@ -1,39 +1,90 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <%- include('partials/head'); %>
+    <%- include('partials/head'); -%>
   </head>
-
-<body>
-  <div class="container mt-5">
-    <div class="welcome">
-      EPFL Start page
-    </div>
-    <hr>
-    <div class="col-auto">
-      <label class="sr-only" for="inlineFormInputGroup">Username</label>
-      <div class="input-group mb-2">
-        <div class="input-group-prepend">
-          <button id="search_on" class="btn bg-gray-200 dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">EPFL</button>
-          <div class="dropdown-menu">
-            <a class="dropdown-item" href="#"><img class="dropdown-item-image" src="https://www.google.com/favicon.ico" width="16px"> Google</a>
-            <a class="dropdown-item" href="#"><img class="dropdown-item-image" src="https://duckduckgo.com/favicon.ico" width="16px"> DuckDuckGo</a>
-            <div role="separator" class="dropdown-divider"></div>
-            <a class="dropdown-item" href="#"><img class="dropdown-item-image" src="https://www.epfl.ch/wp/6/wp-content/themes/wp-theme-2018/assets/favicons/favicon-16.png"> EPFL</a>
-            <a class="dropdown-item" href="#"><img class="dropdown-item-image" src="https://go.epfl.ch/favicon/favicon.ico" width="16px"> EPFL Go</a>
-            <a class="dropdown-item" href="#">EPFL Map</a>
-            <a class="dropdown-item" href="#">EPFL People</a>
-            <a class="dropdown-item" href="#">EPFL Units</a>
-            <a class="dropdown-item" href="#"><img class="dropdown-item-image" src="https://www.servicenow.com/content/dam/servicenow-assets/public/en-us/images/og-images/favicon.ico" width="16px"> ServiceNow</a>
-            <div role="separator" class="dropdown-divider"></div>
-            <a class="dropdown-item" href="#"><img class="dropdown-item-image" src="https://fr.wikipedia.org/static/apple-touch/wikipedia.png" width="16px"> Wikipedia</a>
+  <body>
+    <div class="container mt-5">
+      <div class="welcome">EPFL Start page</div>
+      <hr />
+      <div class="col-auto">
+        <label class="sr-only" for="dynamic_search">Search</label>
+        <div class="input-group mb-2">
+          <div class="input-group-prepend">
+            <button
+              id="search_on"
+              class="btn bg-gray-200 dropdown-toggle"
+              type="button"
+              data-toggle="dropdown"
+              aria-haspopup="true"
+              aria-expanded="false"
+            >
+              EPFL
+            </button>
+            <div class="dropdown-menu">
+              <a class="dropdown-item" href="#"
+                ><img
+                  class="dropdown-item-image"
+                  src="https://www.google.com/favicon.ico"
+                  width="16px"
+                />
+                Google</a
+              >
+              <a class="dropdown-item" href="#"
+                ><img
+                  class="dropdown-item-image"
+                  src="https://duckduckgo.com/favicon.ico"
+                  width="16px"
+                />
+                DuckDuckGo</a
+              >
+              <div role="separator" class="dropdown-divider"></div>
+              <a class="dropdown-item" href="#"
+                ><img
+                  class="dropdown-item-image"
+                  src="https://www.epfl.ch/wp/6/wp-content/themes/wp-theme-2018/assets/favicons/favicon-16.png"
+                />
+                EPFL</a
+              >
+              <a class="dropdown-item" href="#"
+                ><img
+                  class="dropdown-item-image"
+                  src="https://go.epfl.ch/favicon/favicon.ico"
+                  width="16px"
+                />
+                EPFL Go</a
+              >
+              <a class="dropdown-item" href="#">EPFL Map</a>
+              <a class="dropdown-item" href="#">EPFL People</a>
+              <a class="dropdown-item" href="#">EPFL Units</a>
+              <a class="dropdown-item" href="#"
+                ><img
+                  class="dropdown-item-image"
+                  src="https://www.servicenow.com/content/dam/servicenow-assets/public/en-us/images/og-images/favicon.ico"
+                  width="16px"
+                />
+                ServiceNow</a
+              >
+              <div role="separator" class="dropdown-divider"></div>
+              <a class="dropdown-item" href="#"
+                ><img
+                  class="dropdown-item-image"
+                  src="https://fr.wikipedia.org/static/apple-touch/wikipedia.png"
+                  width="16px"
+                />
+                Wikipedia</a
+              >
+            </div>
           </div>
+          <input
+            id="dynamic_search"
+            type="text"
+            class="form-control"
+            placeholder="Search…"
+          />
         </div>
-        <input id="dynamic_search" type="text" class="form-control" placeholder="Search…">
       </div>
     </div>
-  </div>
-
-    <footer><%- include('partials/footer'); %></footer>
+    <footer><%- include('partials/footer'); -%></footer>
   </body>
 </html>

--- a/src/views/pages/home.ejs
+++ b/src/views/pages/home.ejs
@@ -16,17 +16,17 @@
         <div class="input-group-prepend">
           <button id="search_on" class="btn bg-gray-200 dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">EPFL</button>
           <div class="dropdown-menu">
-            <a class="dropdown-item" href="#">Google</a>
-            <a class="dropdown-item" href="#">DuckDuckGo</a>
+            <a class="dropdown-item" href="#"><img class="dropdown-item-image" src="https://www.google.com/favicon.ico" width="16px"> Google</a>
+            <a class="dropdown-item" href="#"><img class="dropdown-item-image" src="https://duckduckgo.com/favicon.ico" width="16px"> DuckDuckGo</a>
             <div role="separator" class="dropdown-divider"></div>
-            <a class="dropdown-item" href="#">EPFL</a>
-            <a class="dropdown-item" href="#">EPFL Go</a>
+            <a class="dropdown-item" href="#"><img class="dropdown-item-image" src="https://www.epfl.ch/wp/6/wp-content/themes/wp-theme-2018/assets/favicons/favicon-16.png"> EPFL</a>
+            <a class="dropdown-item" href="#"><img class="dropdown-item-image" src="https://go.epfl.ch/favicon/favicon.ico" width="16px"> EPFL Go</a>
             <a class="dropdown-item" href="#">EPFL Map</a>
             <a class="dropdown-item" href="#">EPFL People</a>
             <a class="dropdown-item" href="#">EPFL Units</a>
-            <a class="dropdown-item" href="#">ServiceNow</a>
+            <a class="dropdown-item" href="#"><img class="dropdown-item-image" src="https://www.servicenow.com/content/dam/servicenow-assets/public/en-us/images/og-images/favicon.ico" width="16px"> ServiceNow</a>
             <div role="separator" class="dropdown-divider"></div>
-            <a class="dropdown-item" href="#">Wikipedia</a>
+            <a class="dropdown-item" href="#"><img class="dropdown-item-image" src="https://fr.wikipedia.org/static/apple-touch/wikipedia.png" width="16px"> Wikipedia</a>
           </div>
         </div>
         <input id="dynamic_search" type="text" class="form-control" placeholder="Search…">

--- a/src/views/pages/home.ejs
+++ b/src/views/pages/home.ejs
@@ -6,23 +6,15 @@
 
   <body>
     <div class="container mt-5">
-      <div class="search-bar">
-        <div class="d-flex">
-          <div class="w-100 mr-2">
-            <p class="search-container icon-right">
-              <input
-                id="search-input"
-                type="search"
-                name="search"
-                placeholder="Search…"
-                autofocus="autofocus"
-                class="form-control form-control-search"
-              />
-              <svg aria-hidden="true" class="icon">
-                <use xlink:href="#icon-search"></use>
-              </svg>
-            </p>
+      EPFL start page
+      <hr>
+      <div class="col-auto">
+        <label class="sr-only" for="inlineFormInputGroup">Username</label>
+        <div class="input-group mb-2">
+          <div class="input-group-prepend">
+            <div id="search_on" class="input-group-text">EPFL</div>
           </div>
+          <input id="dynamic_search" type="text" class="form-control" placeholder="Search…">
         </div>
       </div>
     </div>

--- a/src/views/pages/home.ejs
+++ b/src/views/pages/home.ejs
@@ -4,20 +4,35 @@
     <%- include('partials/head'); %>
   </head>
 
-  <body>
-    <div class="container mt-5">
-      EPFL start page
-      <hr>
-      <div class="col-auto">
-        <label class="sr-only" for="inlineFormInputGroup">Username</label>
-        <div class="input-group mb-2">
-          <div class="input-group-prepend">
-            <div id="search_on" class="input-group-text">EPFL</div>
+<body>
+  <div class="container mt-5">
+    <div class="welcome">
+      EPFL Start page
+    </div>
+    <hr>
+    <div class="col-auto">
+      <label class="sr-only" for="inlineFormInputGroup">Username</label>
+      <div class="input-group mb-2">
+        <div class="input-group-prepend">
+          <button id="search_on" class="btn bg-gray-200 dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">EPFL</button>
+          <div class="dropdown-menu">
+            <a class="dropdown-item" href="#">Google</a>
+            <a class="dropdown-item" href="#">DuckDuckGo</a>
+            <div role="separator" class="dropdown-divider"></div>
+            <a class="dropdown-item" href="#">EPFL</a>
+            <a class="dropdown-item" href="#">EPFL Go</a>
+            <a class="dropdown-item" href="#">EPFL Map</a>
+            <a class="dropdown-item" href="#">EPFL People</a>
+            <a class="dropdown-item" href="#">EPFL Units</a>
+            <a class="dropdown-item" href="#">ServiceNow</a>
+            <div role="separator" class="dropdown-divider"></div>
+            <a class="dropdown-item" href="#">Wikipedia</a>
           </div>
-          <input id="dynamic_search" type="text" class="form-control" placeholder="Search…">
         </div>
+        <input id="dynamic_search" type="text" class="form-control" placeholder="Search…">
       </div>
     </div>
+  </div>
 
     <footer><%- include('partials/footer'); %></footer>
   </body>

--- a/src/views/pages/partials/footer.ejs
+++ b/src/views/pages/partials/footer.ejs
@@ -3,3 +3,4 @@
   featherSvgPath = 'https://web2018.epfl.ch/6.4.0/icons/feather-sprite.svg';
 </script>
 <script src="https://web2018.epfl.ch/6.4.0/js/elements.min.js"></script>
+<script src="/js/search.js"></script>


### PR DESCRIPTION
This commit bring a new search bar that allow users to enter keyword to  choose type of search. For now it is hard coded and inclues:
* `?` for Google
* `g` for Go EPFL
* `m` for EPFL Map
* `p` for EPFL People
* `sn` for ServiceNow
* `u` for EPFL Units

The <kbd>Esc</kbd> key clear the search input.

This still need some work but can be used as POC.

![smart-search](https://github.com/epfl-si/startpage/assets/176002/adf442ae-62b0-45ac-900a-7c291261e2ec)
