### PR TITLE
[fix] invisible chars in `searchEngine` variable

### DIFF
--- a/src/public/js/search.js
+++ b/src/public/js/search.js
@@ -3,7 +3,7 @@ const setSearchOn = (searchEngine, keepValue = '') => {
   $('#dynamic_search').val(keepValue);
 };
 const doSearchAction = (terms) => {
-  const searchEngine = $('#search_on').text();
+  const searchEngine = $('#search_on').text().trim();
   if (searchEngine === 'DuckDuckGo') {
     window.open('https://duckduckgo.com/?q=' + terms);
   }


### PR DESCRIPTION
The `searchEngine` used to select the action for each search wasn't using a proper trim function, resulting in invalid match due to spaces.